### PR TITLE
Modified logic parser to accept conditional expressions and boolean variables defined in the .cfg

### DIFF
--- a/maboss/gsparser.py
+++ b/maboss/gsparser.py
@@ -112,7 +112,11 @@ def load(bnd_filename, cfg_filename):
 
         nodes = _read_bnd(bnd_content, is_internal_list)
 
-        net = Network(nodes)
+        # Some boolean variables can be defined in the .cfg and used in the .bnd
+        # We need to know about them when checking the logical formulae.
+        boolean_variables = ["$%s" % var for var, value in variables.items() if value in ['TRUE', 'FALSE']]
+
+        net = Network(nodes, boolean_variables)
         for istate in istate_list:
             net.set_istate(istate, istate_list[istate])
         for v in variables:
@@ -159,6 +163,7 @@ def _read_cfg(string):
 def _read_bnd(string, is_internal_list):
         nodes = []
         parse_bnd = bnd_grammar.parseString(string)
+
         for token in parse_bnd:
             interns = {v.lhs: v.rhs for v in token.interns}
             logic = interns.pop('logic') if 'logic' in interns else None

--- a/maboss/logic.py
+++ b/maboss/logic.py
@@ -10,14 +10,17 @@ boolNot = pp.oneOf("! NOT")
 boolAnd = pp.oneOf("&& & AND")
 boolOr = pp.oneOf("|| | OR")
 boolXor = pp.oneOf("^ XOR")
-varName = (~boolAnd + ~boolOr + ~boolXor + ~boolNot + ~boolCst
-           + ~pp.Literal('Node') + pp.Word(pp.alphas, pp.alphanums+'_'))
+boolTest = pp.Literal("?")
+boolElse = pp.Literal(":")
+varName = (~boolAnd + ~boolOr + ~boolXor + ~boolNot + ~boolCst + ~boolTest + ~boolElse
+           + ~pp.Literal('Node') + pp.Word(pp.alphas+'$', pp.alphanums+'_'))
 varName.setParseAction(lambda token: token[0])
 lparen = '('
 rparen = ')'
 logTerm = (pp.Optional(boolNot)
            + (boolCst | varName | (lparen + logExp + rparen)))
-logAnd = logTerm + pp.ZeroOrMore(boolAnd + logTerm)
+logIFE = logTerm + pp.ZeroOrMore(boolTest + logTerm + boolElse + logTerm)
+logAnd = logIFE + pp.ZeroOrMore(boolAnd + logTerm)
 logOr = logAnd + pp.ZeroOrMore(boolOr + logAnd)
 logExp << pp.Combine(logOr + pp.ZeroOrMore(boolXor + logOr), adjacent=False, joinString=' ')
 

--- a/maboss/network.py
+++ b/maboss/network.py
@@ -99,12 +99,12 @@ class Network(dict):
     Network objects are in charge of carrying the initial states of each node.
     """
 
-    def __init__(self, nodeList):
+    def __init__(self, nodeList, booleanVariablesList):
         super().__init__({nd.name: nd for nd in nodeList})
         self.names = [nd.name for nd in nodeList]
         self.logicExp = {nd.name: nd.logExp for nd in nodeList}
 
-        if not logic._check_logic_defined(self.names,
+        if not logic._check_logic_defined(self.names + booleanVariablesList,
                                           [nd.logExp for nd in nodeList if nd.logExp]):
             raise ValueError("Some logic rule had unkown variables")
 


### PR DESCRIPTION
I found a problem with the logic parser using the p53/Mdm2 model available on MaBoSS website.
Logic definitions like this one : 

```
node Mdm2C
{
  logic = $case_a ? p53_h : p53;
  rate_up = (@logic ? 1.0 : 0.0)/$tMCu;
  rate_down = (@logic ? 0.0 : 1.0)/$tMCd;
}
```

would produce this error message : 

> Warning, syntax error: $case_a ? p53_h : p53
> logExp set to None

The problem was that conditional expressions were not defined in the logic, so I added them. Hopefully I did it well, but please check.

The other problem is that this expression is using the variable $case_a, which is defined in the .cfg.
I also added support in the logic definition for these variables (by authorizing variables to start with a '$'), and I added boolean variables defined in the .cfg to the list of variables used during the logic verification. 