### PR TITLE
Modified logic parser to accept conditional expressions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ build
 .*.sw*
 gen
 *.log
+!test/p53_Mdm2.bnd
+!test/p53_Mdm2_runcfg.cfg

--- a/maboss/gsparser.py
+++ b/maboss/gsparser.py
@@ -112,7 +112,11 @@ def load(bnd_filename, cfg_filename):
 
         nodes = _read_bnd(bnd_content, is_internal_list)
 
-        net = Network(nodes)
+        # Some boolean variables can be defined in the .cfg and used in the .bnd
+        # We need to know about them when checking the logical formulae.
+        boolean_variables = ["$%s" % var for var, value in variables.items() if value in ['TRUE', 'FALSE']]
+
+        net = Network(nodes, boolean_variables)
         for istate in istate_list:
             net.set_istate(istate, istate_list[istate])
         for v in variables:
@@ -159,6 +163,7 @@ def _read_cfg(string):
 def _read_bnd(string, is_internal_list):
         nodes = []
         parse_bnd = bnd_grammar.parseString(string)
+
         for token in parse_bnd:
             interns = {v.lhs: v.rhs for v in token.interns}
             logic = interns.pop('logic') if 'logic' in interns else None

--- a/maboss/logic.py
+++ b/maboss/logic.py
@@ -10,8 +10,10 @@ boolNot = pp.oneOf("! NOT")
 boolAnd = pp.oneOf("&& & AND")
 boolOr = pp.oneOf("|| | OR")
 boolXor = pp.oneOf("^ XOR")
-varName = (~boolAnd + ~boolOr + ~boolXor + ~boolNot + ~boolCst
-           + ~pp.Literal('Node') + pp.Word(pp.alphas, pp.alphanums+'_'))
+boolTest = pp.Literal("?")
+boolElse = pp.Literal(":")
+varName = (~boolAnd + ~boolOr + ~boolXor + ~boolNot + ~boolCst + ~boolTest + ~boolElse
+           + ~pp.Literal('Node') + pp.Word(pp.alphas+'$', pp.alphanums+'_'))
 varName.setParseAction(lambda token: token[0])
 lparen = '('
 rparen = ')'
@@ -19,7 +21,9 @@ logTerm = (pp.Optional(boolNot)
            + (boolCst | varName | (lparen + logExp + rparen)))
 logAnd = logTerm + pp.ZeroOrMore(boolAnd + logTerm)
 logOr = logAnd + pp.ZeroOrMore(boolOr + logAnd)
-logExp << pp.Combine(logOr + pp.ZeroOrMore(boolXor + logOr), adjacent=False, joinString=' ')
+logXor = logOr + pp.ZeroOrMore(boolXor + logOr)
+logIFE = logXor + pp.ZeroOrMore(boolTest + logXor + boolElse + logXor)
+logExp << pp.Combine(logIFE, adjacent=False, joinString=' ')
 
 
 def _check_logic_syntax(string):

--- a/maboss/network.py
+++ b/maboss/network.py
@@ -99,12 +99,12 @@ class Network(dict):
     Network objects are in charge of carrying the initial states of each node.
     """
 
-    def __init__(self, nodeList):
+    def __init__(self, nodeList, booleanVariablesList):
         super().__init__({nd.name: nd for nd in nodeList})
         self.names = [nd.name for nd in nodeList]
         self.logicExp = {nd.name: nd.logExp for nd in nodeList}
 
-        if not logic._check_logic_defined(self.names,
+        if not logic._check_logic_defined(self.names + booleanVariablesList,
                                           [nd.logExp for nd in nodeList if nd.logExp]):
             raise ValueError("Some logic rule had unkown variables")
 

--- a/test/p53_Mdm2.bnd
+++ b/test/p53_Mdm2.bnd
@@ -1,0 +1,67 @@
+node p53
+{
+  logic = NOT Mdm2N;
+  rate_up = (@logic ? 1.0 : 0.0)/$tp53u ;
+  rate_down = (((NOT @logic) AND NOT p53_h) ? 1.0 : 0.0)/$tp53d ;
+}
+
+node p53_h
+{
+  logic = NOT Mdm2N;
+  rate_up = ((@logic AND p53) ? 1.0 : 0.0)/$tp53hu;
+  rate_down = ((@logic ? 0.0 : 1.0))/$tp53hd;
+}
+
+node Mdm2C
+{
+  logic = $case_a ? p53_h : p53;
+  rate_up = (@logic ? 1.0 : 0.0)/$tMCu;
+  rate_down = (@logic ? 0.0 : 1.0)/$tMCd;
+}
+
+node Mdm2N
+{
+  logic_p53 = $case_a ? p53 : p53_h;
+  rate_up = (((@logic_p53 AND Mdm2C AND Dam) ? $KMn_pMCD : 0.0) +
+            ((@logic_p53 AND Mdm2C AND (NOT Dam)) ? $KMn_pMC : 0.0) +
+		((@logic_p53 AND (NOT Mdm2C) AND Dam) ? $KMn_pD : 0.0) +
+		((@logic_p53 AND (NOT Mdm2C) AND (NOT Dam)) ? $KMn_p : 0.0) +
+		((NOT @logic_p53 AND Mdm2C AND Dam) ? $KMn_MCD : 0.0) +
+		((NOT @logic_p53 AND Mdm2C AND (NOT Dam)) ? $KMn_MC : 0.0) +
+            ((NOT @logic_p53 AND NOT Mdm2C AND Dam) ? $KMn_D : 0.0) +
+ 		((NOT @logic_p53 AND NOT Mdm2C AND (NOT Dam)) ? $KMn : 0.0))/$tMNu;
+
+// case_a = TRUE means that p53 inhibits Mdm2N at level 1 in the presence of DNA damage
+// if p53 and MDM2C are present when DNA damage and Kmn_pMCD=1 => despite the presence of p53 and DNA damage, MDM2N can activate
+// if this is not true, then 7 exclusive cases are possible (8 cases total): 
+// (1) if p53 is active and Mdm2C is active in the absence of DNA damage, Mdm2N can activate OR
+// (2) if p53 is active and not Mdm2C in the presence of DNA damage, Mdm2N cannot activate (KMn_pD=0) OR 
+// 
+// (4) if Mdm2C is active and not p53 in the presence of DNA damage, Mdm2N can activate (KMn_MCD=1) OR
+// 
+// (7) if p53 is inactive and Mdm2C is inactive in the absence of DNA damage, Mdm2N cannot activate (KMn=0 no spontaneous activation)
+
+  rate_down = (((@logic_p53 AND Mdm2C AND Dam) ? (1-$KMn_pMCD) : 0.0) +
+            ((@logic_p53 AND Mdm2C AND (NOT Dam)) ? (1-$KMn_pMC) : 0.0) +
+		((@logic_p53 AND (NOT Mdm2C) AND Dam) ? (1-$KMn_pD) : 0.0) +
+		((@logic_p53 AND (NOT Mdm2C) AND (NOT Dam)) ? (1-$KMn_p) : 0.0) +
+		((NOT @logic_p53 AND Mdm2C AND Dam) ? (1-$KMn_MCD) : 0.0) +
+		((NOT @logic_p53 AND Mdm2C AND (NOT Dam)) ? (1-$KMn_MC) : 0.0) +
+            ((NOT @logic_p53 AND NOT Mdm2C AND Dam) ? (1-$KMn_D) : 0.0) +
+ 		((NOT @logic_p53 AND NOT Mdm2C AND (NOT Dam)) ? (1-$KMn) : 0.0))/$tMNd;
+
+// Everything that can inactivate Mdm2N is the opposite of what can activate it. 
+// This ensures that what gets activated remains active
+
+}
+
+node Dam
+{
+  logic = $case_a ? p53_h : p53;
+  rate_up = @logic ? 0.0 : 0.0;
+  rate_down = (@logic ? 1.0 : 0.0)/$tDd;
+
+// Stress is implicit in the initial condition
+}
+
+//

--- a/test/p53_Mdm2_runcfg.cfg
+++ b/test/p53_Mdm2_runcfg.cfg
@@ -1,0 +1,54 @@
+$fast = 100;
+$case_a = TRUE;
+
+// Figure 5a Kauffmann
+$KMn=1;
+$KMn_p=0;
+$KMn_MC=1;
+$KMn_pMC=1;
+$KMn_D=0;
+$KMn_pD=0;
+$KMn_MCD=1;
+$KMn_pMCD=1;
+
+$tp53u=2;
+$tp53d=2;
+$tp53hu=1;
+$tp53hd=1;
+
+$tMCu=0.6;
+$tMCd=1;
+
+$tMNu=0.3;
+$tMNd=1;
+
+$tDd=5;
+
+Dam.istate = TRUE;
+Mdm2N.istate = TRUE ;
+p53.istate = FALSE;
+p53_h.istate = FALSE;
+//sample_count = 1000;
+sample_count = 50000;
+// max_time = 40;
+max_time = 50;
+time_tick = 0.1;
+//time_tick = 5;
+discrete_time = 0;
+use_physrandgen = FALSE;
+seed_pseudorandom = 100;
+//display_traj = TRUE;
+
+//Mdm2C.is_internal = TRUE;
+//Mdm2N.is_internal = TRUE;
+//Dam.is_internal = TRUE;
+//p53.is_internal = TRUE;
+
+//Mdm2C.refstate = 0;
+p53.refstate = 0;
+p53_h.refstate = 0;
+//Mdm2N.refstate = 0;
+thread_count = 1;
+
+statdist_traj_count = 100;
+statdist_cluster_threshold = 0.9;

--- a/test/test_loadmodels.py
+++ b/test/test_loadmodels.py
@@ -1,0 +1,8 @@
+"""Test suite for loading models."""
+
+
+from maboss import load
+from os.path import dirname, join
+
+sim = load(join(dirname(__file__), "p53_Mdm2.bnd"), join(dirname(__file__), "p53_Mdm2_runcfg.cfg"))
+assert(sim.network['Mdm2C'].logExp == "$case_a ? p53_h : p53")

--- a/test/test_logic.py
+++ b/test/test_logic.py
@@ -19,4 +19,10 @@ assert(not logic._check_logic_defined(['foo', 'bar'], ['(foo && barr)']))
 print("    light syntax")
 assert(logic._check_logic_defined(['a', 'b', 'c', 'd'], ["a & !b AND c OR a & b & !c OR !a & b & c"]))
 
+print("   conditional expression")
+assert(logic._check_logic_defined(['a', 'b', 'c'], ["a ? b : c"]))
+
+print("   other operators within conditional expression")
+assert(logic._check_logic_defined(['a', 'b', 'c', 'd', 'e', 'f', 'g'], ["a & b ^ !c ? d | !e : f ^ g"]))
+
 print("All test passed")


### PR DESCRIPTION
I found a problem with the logic parser using the p53/Mdm2 model available on MaBoSS website.
Logic definitions like this one : 

```
node Mdm2C
{
  logic = $case_a ? p53_h : p53;
  rate_up = (@logic ? 1.0 : 0.0)/$tMCu;
  rate_down = (@logic ? 0.0 : 1.0)/$tMCd;
}
```

would produce this error message : 

> Warning, syntax error: $case_a ? p53_h : p53
> logExp set to None

The problem was that conditional expressions were not defined in the logic, so I added them. Hopefully this time I did it well, but please check.

The other problem is that this expression is using the variable $case_a, which is defined in the .cfg.
I also added support in the logic definition for these variables (by authorizing variables to start with a '$'), and I added boolean variables defined in the .cfg to the list of variables used during the logic verification. 