### PR TITLE
Simulation parameters now default to an empty OrderedDict

### DIFF
--- a/maboss/simulation.py
+++ b/maboss/simulation.py
@@ -51,7 +51,7 @@ class Simulation(object):
     """
 
 
-    def __init__(self, nt, parameters=None, **kwargs):
+    def __init__(self, nt, parameters=collections.OrderedDict({}), **kwargs):
         """
         Initialize the Simulation object.
 


### PR DESCRIPTION
The None value for default parameters prevents us to iterate over it, returning : 
 
```
File "/home/travis/build/vincent-noel/pyMaBoSS/maboss/simulation.py", line 67, in __init__
    for p in cfg:
TypeError: 'NoneType' object is not iterable
```

Using an empty OrderedDict as a default should fix it.