### PR TITLE
Forcing timestep as a float

### DIFF
--- a/maboss/upp/upp.py
+++ b/maboss/upp/upp.py
@@ -21,7 +21,7 @@ class UpdatePopulation:
         self.uppfile = uppfile
         self.workdir = workdir
 
-        self.time_step = model.param['max_time']
+        self.time_step = float(model.param['max_time'])
         self.time_shift = 0.0
         self.base_ratio = 1.0
 


### PR DESCRIPTION
The timestep, which we get from maboss 'max_time', can be a string. 
In this patch, we force the conversion to float.
