### PR TITLE
Adding the option to load multiple cfg files, the right way

### DIFF
--- a/maboss/gsparser.py
+++ b/maboss/gsparser.py
@@ -96,7 +96,7 @@ cfg_grammar = pp.ZeroOrMore(cfg_decl)
 cfg_grammar.ignore('//' + pp.restOfLine)
 
 
-def load(bnd_filename, cfg_filename):
+def load(bnd_filename, *cfg_filenames):
     """Loads a network from a MaBoSS format file.
 
     :param str bnd_filename: Network file
@@ -105,13 +105,18 @@ def load(bnd_filename, cfg_filename):
     :rtype: :py:class:`.Simulation`
     """
     assert bnd_filename.lower().endswith(".bnd"), "wrong extension for bnd file"
-    assert cfg_filename.lower().endswith(".cfg"), "wrong extension for cfg file"
+
+    if not cfg_filenames: 
+        cfg_filenames = [".".join([".".join(bnd_filename.split(".")[:-1]), "cfg"])]
 
     with ExitStack() as stack:
         bnd_file = stack.enter_context(open(bnd_filename, 'r'))
-        cfg_file = stack.enter_context(open(cfg_filename, 'r'))
         bnd_content = bnd_file.read()
-        cfg_content = cfg_file.read()
+
+        cfg_content = ""
+        for cfg_filename in tuple(cfg_filenames):
+            cfg_file = stack.enter_context(open(cfg_filename, 'r'))
+            cfg_content += cfg_file.read()
 
         (variables, parameters, is_internal_list,
          istate_list, refstate_list) = _read_cfg(cfg_content)

--- a/maboss/gsparser.py
+++ b/maboss/gsparser.py
@@ -96,32 +96,22 @@ cfg_grammar = pp.ZeroOrMore(cfg_decl)
 cfg_grammar.ignore('//' + pp.restOfLine)
 
 
-def load(bnd_filename, cfg_filename=None, cfg_filenames=[]):
+def load(bnd_filename, cfg_filename):
     """Loads a network from a MaBoSS format file.
 
     :param str bnd_filename: Network file
     :param str cfg_filename: Configuraton file
-    :param list cfg_filenames: List of configuration files
     :keyword str simulation_name: name of the returned :py:class:`.Simulation` object
     :rtype: :py:class:`.Simulation`
     """
-    assert cfg_filename is not None or len(cfg_filenames) > 0, "need at list one cfg file"
     assert bnd_filename.lower().endswith(".bnd"), "wrong extension for bnd file"
-    assert cfg_filename is None or cfg_filename.lower().endswith(".cfg"), "wrong extension for cfg file"
+    assert cfg_filename.lower().endswith(".cfg"), "wrong extension for cfg file"
 
     with ExitStack() as stack:
         bnd_file = stack.enter_context(open(bnd_filename, 'r'))
+        cfg_file = stack.enter_context(open(cfg_filename, 'r'))
         bnd_content = bnd_file.read()
-
-        cfg_content = ""
-        if cfg_filename is not None:
-            cfg_file = stack.enter_context(open(cfg_filename, 'r'))
-            cfg_content = cfg_file.read()
-
-        elif len(cfg_filenames) > 0:
-            for t_cfg_filename in cfg_filenames:
-                cfg_file = stack.enter_context(open(t_cfg_filename, 'r'))
-                cfg_content += cfg_file.read()
+        cfg_content = cfg_file.read()
 
         (variables, parameters, is_internal_list,
          istate_list, refstate_list) = _read_cfg(cfg_content)

--- a/test/cellcycle.bnd
+++ b/test/cellcycle.bnd
@@ -1,0 +1,71 @@
+node CycD
+{
+  logic = CycD;
+  rate_up = @logic ? $fast : 0.0;
+  rate_down = @logic ? 0.0 : $fast;
+}
+
+node CycE
+{
+  logic = !Rb & E2F;
+  rate_up = @logic ? $slow : 0.0;
+  rate_down = @logic ? 0.0 : $fast;
+}
+
+node CycA
+{
+  logic = !Rb & !Cdc20 & !(UbcH10 & cdh1) & (CycA | E2F);
+  rate_up = @logic ? $slow : 0.0;
+  rate_down = @logic ? 0.0 : $fast;
+}
+
+
+node CycB
+{
+  logic = !Cdc20 & !cdh1;
+  rate_up = @logic ? $slow : 0.0;
+  rate_down = @logic ? 0.0 : $fast;
+}
+
+node Rb
+{
+  logic = !CycD & !CycB & (p27 | !(CycA | CycE));
+  rate_up = @logic ? $fast : log(1.0, 2);
+  rate_down = @logic ? 0.0 : $fast;
+}
+
+node E2F
+{
+  logic = !Rb & !CycB & (!CycA | p27);
+  rate_up = @logic ? $slow : 0.0;
+  rate_down = @logic ? 0.0 : $fast;
+ }
+
+
+node p27
+{
+  logic = !CycD & !CycB & (!(CycA | CycE) | (p27 & !(CycE & CycA)));
+  rate_up = @logic ? $fast : 0.0;
+  rate_down = @logic ? 0.0 : $fast;
+}
+
+node Cdc20
+{
+  logic = CycB;
+  rate_up = @logic ? $slow : 0.0;
+  rate_down = @logic ? 0.0 : $fast;
+}
+
+node UbcH10
+{
+  logic = (!(cdh1 & !UbcH10) & (CycA | CycB)) | (!CycA & !CycB & (!cdh1 | (Cdc20 & UbcH10)));
+  rate_up = @logic ? $slow : 0.0;
+  rate_down = @logic ? 0.0 : $fast;
+}
+
+node cdh1
+{
+  logic = Cdc20 | (!CycB & (!CycA | p27));
+  rate_up = @logic ? $fast : 0.0;
+  rate_down = @logic ? 0.0 : $fast;
+}

--- a/test/cellcycle_runcfg-thread_1.cfg
+++ b/test/cellcycle_runcfg-thread_1.cfg
@@ -1,0 +1,7 @@
+// 1 thread
+use_physrandgen = FALSE;
+seed_pseudorandom = 100;
+thread_count = 1;
+statdist_cluster_threshold = 0.96;
+statdist_traj_count = 5000;
+

--- a/test/cellcycle_runcfg.cfg
+++ b/test/cellcycle_runcfg.cfg
@@ -1,0 +1,40 @@
+$fast=10;
+$slow=1;
+// Initial conditions
+// A.istate = 1;
+// if nothing, initial condition is randomly chosen
+CycD.istate=1;
+CycE.istate=0;
+CycA.istate=0;
+CycB.istate = 0;
+Rb.istate=0;
+E2F.istate=0;
+p27.istate=0;
+Cdc20.istate=0;
+UbcH10.istate=0;
+cdh1.istate=1;
+Rb.is_internal=TRUE;
+E2F.is_internal = TRUE;
+p27.is_internal=TRUE;
+Cdc20.is_internal = TRUE;
+UbcH10.is_internal = TRUE;
+cdh1.is_internal=TRUE;
+
+
+// number of trajectories
+sample_count = 1000000;
+
+// maximum time of a trajectory - 
+// after max_time is reached, the computation stops
+max_time = 5;
+
+// time of an interval on which probabilities are computed and averaged
+time_tick = .2;
+
+// if discrete time is 1, the computation is fully discrete
+// in this case, the time interval is equal to time tick
+// if discrete time is 0, the computation is continuous
+// in this case, the time interval is chosen randomly
+discrete_time = 1;
+//use_physrandgen = TRUE;
+seed_pseudorandom = 100;

--- a/test/test_loadmodels.py
+++ b/test/test_loadmodels.py
@@ -52,3 +52,17 @@ class TestLoadModels(TestCase):
 		for i, proba in enumerate(probas):
 			self.assertAlmostEqual(proba, expected_probas[i], delta=proba*1e-6)
 			
+	def test_load_multiple_cfgs(self):
+
+		sim = load(join(dirname(__file__), "reprod_all.bnd"))
+
+		sim2 = load(
+			join(dirname(__file__), "p53_Mdm2.bnd"), 
+			join(dirname(__file__), "p53_Mdm2_runcfg.cfg")
+		)
+
+		sim3 = load(
+			join(dirname(__file__), "cellcycle.bnd"),
+			join(dirname(__file__), "cellcycle_runcfg.cfg"),
+			join(dirname(__file__), "cellcycle_runcfg-thread_1.cfg")
+		)


### PR DESCRIPTION
This fix reverts the last pull request, and changes the way multiples cfg files can be loaded.
The syntax becomes the following : 

load(bnd_file, cfg_file1, cfg_file2, ...)

Note that the following syntax is also correct : 

load(bnd_file)

This will look for a cfg file with the same name as the bnd file (minus the extension), and load it. 

I also included a simple test case.