### PR TITLE
Fixing model verification when number of nodes > 64

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pyMaBoSS" %}
-{% set version = "0.7.3" %}
+{% set version = "0.7.4" %}
 package:
   name: '{{ name|lower }}'
   version: '{{ version }}'

--- a/maboss/simulation.py
+++ b/maboss/simulation.py
@@ -120,7 +120,7 @@ class Simulation(object):
                 self.print_cfg(out=cfg_file)
 
             proc = subprocess.Popen(
-                ["MaBoSS", "--check", "-c", cfg_path, bnd_path],
+                [self.get_maboss_cmd(), "--check", "-c", cfg_path, bnd_path],
                 cwd=path, stdout=subprocess.PIPE, stderr=subprocess.PIPE
             )
             (t_stdout, t_stderr) = proc.communicate()

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ if version_info[0] < 3:
     optional_contextlib.append("contextlib2")
 
 setup(name='maboss',
-    version="0.7.3",
+    version="0.7.4",
     packages=find_packages(exclude=["test"]),
     py_modules = ["maboss_setup"],
     author="Nicolas Levy",


### PR DESCRIPTION
The model verification wasn't adapting the maboss command to the number of its nodes. 