### PR TITLE
Added a function to get results file object

### DIFF
--- a/maboss/results/probtrajresult.py
+++ b/maboss/results/probtrajresult.py
@@ -280,10 +280,13 @@ class ProbTrajResult(object):
 
         return self.entropy_probtraj_error
 
+    def _get_probtraj_fd(self):
+        return open(self.get_probtraj_file(), 'r')
+
     def _get_raw_data(self):
     
         if self._raw_data is None:
-            with open(self.get_probtraj_file(), 'r') as probtraj:
+            with self._get_probtraj_fd() as probtraj:
 
                 raw_lines = probtraj.readlines()
 
@@ -297,7 +300,7 @@ class ProbTrajResult(object):
     def _get_raw_last_data(self):
     
         if self._raw_last_data is None:
-            with open(self.get_probtraj_file(), 'r') as probtraj:
+            with self._get_probtraj_fd() as probtraj:
 
                 if self._first_state_index is None:
                     first_line = probtraj.readline()

--- a/maboss/results/statdistresult.py
+++ b/maboss/results/statdistresult.py
@@ -171,9 +171,12 @@ class StatDistResult(object):
                 statdist_table.write("\t".join(line_3) + "\n")
                 statdist_table.write("\n")
 
+    def _get_statdist_fd(self):
+        return open(self.get_statdist_file(), "r")
+
     def _get_raw_statdist(self):
         if self._raw_statdist is None or self._traj_count is None:
-            with open(self.get_statdist_file(), "r") as f:
+            with self._get_statdist_fd() as f:
                 self._raw_statdist = []
                 self._traj_count = None
                 for i, line in enumerate(f.readlines()):
@@ -193,7 +196,7 @@ class StatDistResult(object):
             self._raw_statdist_clusters = []
             self._raw_statdist_clusters_summary = []
 
-            with open(self.get_statdist_file(), "r") as f:
+            with self._get_statdist_fd() as f:
                 started_cluster = False
                 t_cluster = []
                 started_summary = False

--- a/maboss/server/result.py
+++ b/maboss/server/result.py
@@ -79,13 +79,13 @@ class Result(BaseResult):
     def getRunLog(self):
         return self._runlog
 
-    def get_fp_file(self):
+    def _get_fp_fd(self):
         return StringIO(self.getFP())
 
-    def get_probtraj_file(self):
+    def _get_probtraj_fd(self):
         return StringIO(self.getProbTraj())
 
-    def get_statdist_file(self):
+    def _get_statdist_fd(self):
         return StringIO(self.getStatDist())
 
     def get_probtraj_dtypes(self):

--- a/maboss/upp/results.py
+++ b/maboss/upp/results.py
@@ -74,7 +74,7 @@ class UpdatePopulationResults:
         for stepIndex in range(1, self.uppModel.step_number+1):
 
             LastLinePrevTraj = ""                
-            with open(result.get_probtraj_file(), 'r') as PrStepTrajF:
+            with result._get_probtraj_fd() as PrStepTrajF:
                 LastLinePrevTraj = PrStepTrajF.readlines()[-1]
             
             self.pop_ratio *= self._updatePopRatio(LastLinePrevTraj)
@@ -373,8 +373,7 @@ def _get_next_condition_from_trajectory(self, next_model, step=-1):
     name2idx = {}
     for i in range(len(names)): name2idx[ names[i] ] = i
 
-    trajfile = self.results[step].get_probtraj_file()
-    with open(trajfile) as f:
+    with self.results[step]._get_probtraj_fd() as f:
         first_line = f.readline()
         first_col = next(i for i, col in enumerate(first_line.strip("\n").split("\t")) if col == "State")
         last_line = f.readlines()[-1]

--- a/maboss/upp/upp.py
+++ b/maboss/upp/upp.py
@@ -37,8 +37,8 @@ class UpdatePopulation:
 
             self._readUppFile()
 
-    def run(self, workdir=None, overwrite=None, verbose=False):
-        return UpdatePopulationResults(self, verbose, workdir, overwrite, self.previous_run)
+    def run(self, workdir=None, overwrite=None, verbose=False, host=None, port=7777):
+        return UpdatePopulationResults(self, verbose, workdir, overwrite, self.previous_run, host=host, port=port)
 
     def _readUppFile(self):
 

--- a/test/test_server.py
+++ b/test/test_server.py
@@ -23,4 +23,8 @@ class TestServer(TestCase):
 			+ "FP\tProba\tState\tMdm2N\tp53_h\tp53\tMdm2C\tDam\n"
 			+ "#1\t0.90548\tMdm2N\t1\t0\t0\t0\t0\n"
 		)
+
+		res.get_states_probtraj()
+		res.get_statdist_clusters()
+		
 		mbcli.close()

--- a/test/test_uppmaboss.py
+++ b/test/test_uppmaboss.py
@@ -26,6 +26,24 @@ class TestUpPMaBoSS(TestCase):
 		for i, pop_ratio in enumerate(pop_ratios):
 			self.assertAlmostEqual(pop_ratio, expected_pop_ratios[i], delta=pop_ratio/1e-6)
 
+class TestUpPMaBoSSServer(TestCase):
+
+	def test_uppmaboss_server(self):
+
+		sim = load(join(dirname(__file__), "CellFateModel.bnd"), join(dirname(__file__), "CellFateModel_1h.cfg"))
+		uppmaboss_model = UpdatePopulation(sim, join(dirname(__file__), "CellFate_1h.upp"))
+		uppmaboss_sim = uppmaboss_model.run(host='localhost', port=7777)
+		pop_ratios = uppmaboss_sim.get_population_ratios('WT').values.tolist()
+		expected_pop_ratios = [
+			1.0, 0.6899230000000027, 0.6332961899289637, 0.6106773832094052, 0.596996988470672, 0.5764113383141323, 
+			0.5451779135361446, 0.5052152821180231, 0.4627322342599125, 0.4215351834436775, 0.3854876022314294, 
+			0.3557684355373424, 0.33079633751005605
+		]
+
+		for i, pop_ratio in enumerate(pop_ratios):
+			self.assertAlmostEqual(pop_ratio, expected_pop_ratios[i], delta=pop_ratio/1e-6)
+
+
 
 class TestUpPMaBoSSOverwrite(TestCase):
 


### PR DESCRIPTION
Before the improvements I made in the import of statdist and probtrajs, the files were directly given to pandas to read, which was able to read from either the filename or the file object. 
After this modification, pymaboss now read the file directly as text, and the server results (which is a in-memory text stream file object StringIO) were not compatible with it. 

This change corrects this, by creating a function to get the file object for both the classical results (as a file) and the server results (as a string). 

TL;DR : This fixes the import of the server results in pyMaBoSS.

I also added maboss server option for UPMaBoSS.
