### PR TITLE
Load bnet files directly with minibn

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pyMaBoSS" %}
-{% set version = "0.7.6" %}
+{% set version = "0.7.7" %}
 package:
   name: '{{ name|lower }}'
   version: '{{ version }}'

--- a/maboss/ensemble/ensemble.py
+++ b/maboss/ensemble/ensemble.py
@@ -10,8 +10,10 @@ import sys
 from random import random
 import shutil
 import collections
-import biolqm
 import math
+
+from colomoto import minibn
+
 class Ensemble(object):
 
     def __init__(self, path, cfg_filename=None, *args, **kwargs):
@@ -160,9 +162,10 @@ class Ensemble(object):
         if self.minibns is None:
             self.minibns = []
             for model_file in self.models_files:
-                self.minibns.append(
-                    biolqm.to_minibn(biolqm.load(model_file))
-                )
+                assert model_file.lower().endswith(".bnet"), \
+                        "Only .bnet files are supported as input"
+                bn = minibn.BooleanNetwork.load(model_file)
+                self.minibns.append(bn)
 
         return self.minibns
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ if version_info[0] < 3:
     optional_contextlib.append("contextlib2")
 
 setup(name='maboss',
-    version="0.7.6",
+    version="0.7.7",
     packages=find_packages(exclude=["test"]),
     py_modules = ["maboss_setup"],
     author="Nicolas Levy",

--- a/test/test_ensemble.py
+++ b/test/test_ensemble.py
@@ -27,6 +27,7 @@ class TestEnsembleMaBoSS(TestCase):
 			outputs=['AHR', 'BCL6', 'CEBPB'],
 			individual_results=True
 		)
+		self.assertEqual(len(ensemble_model.get_mini_bns()), 5)
 		results = ensemble_model.run()
 
 		results.plotSteadyStatesDistribution()


### PR DESCRIPTION
There is no need of biolqm to load bnet files.
The following patch remove the strong dependency on biolqm and uses `minibn` to load bnet files in the `Ensemble.get_mini_bns` method.

It makes the assumptions that only .bnet files are as input (but bnd format is anyway not supported as import format by biolqm).

By the way, to avoid importing biolqm globally, it is better to use the `import_colomoto_tool` logic within the specific method using it. See for example `simulation.to_biolqm`:
```py
def to_biolqm(maboss_model):
    biolqm = import_colomoto_tool("biolqm")
    ...
```