### PR TITLE
Increase the possible number of nodes to 1024

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pyMaBoSS" %}
-{% set version = "0.7.7" %}
+{% set version = "0.7.8" %}
 package:
   name: '{{ name|lower }}'
   version: '{{ version }}'

--- a/maboss/simulation.py
+++ b/maboss/simulation.py
@@ -147,6 +147,8 @@ class Simulation(object):
         maboss_cmd = "MaBoSS"
 
         l = len(self.network)
+        assert l <= 1024, "Models with more than 1024 nodes are not compatible with this version of MaBoSS"
+
         if l <= 64:
             pass
         elif l <= 128:

--- a/maboss/simulation.py
+++ b/maboss/simulation.py
@@ -151,8 +151,12 @@ class Simulation(object):
             pass
         elif l <= 128:
             maboss_cmd = "MaBoSS_128n"
-        else:
+        elif l <= 256:
             maboss_cmd = "MaBoSS_256n"
+        elif l <= 512:
+            maboss_cmd = "MaBoSS_512n"
+        else:
+            maboss_cmd = "MaBoSS_1024n"
 
         return maboss_cmd
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ if version_info[0] < 3:
     optional_contextlib.append("contextlib2")
 
 setup(name='maboss',
-    version="0.7.7",
+    version="0.7.8",
     packages=find_packages(exclude=["test"]),
     py_modules = ["maboss_setup"],
     author="Nicolas Levy",


### PR DESCRIPTION
pyMaBoSS has a built in mechanism to automatically choose the proper executable according to the number of nodes. 
Until now, this mechanism only worked with less than 256 nodes. This update pushes the limit to 1024 nodes.
