### PR TITLE
Fix/empty nodes probtraj, BNet import, Error check when specifying outputs

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pyMaBoSS" %}
-{% set version = "0.7.8" %}
+{% set version = "0.7.9" %}
 package:
   name: '{{ name|lower }}'
   version: '{{ version }}'

--- a/maboss/__init__.py
+++ b/maboss/__init__.py
@@ -2,7 +2,7 @@ from .network import *
 from .simulation import *
 from .result import *
 from .results import *
-from .gsparser import load
+from .gsparser import load, loadBNet
 from .server import MaBoSSClient
 from .upp import UpdatePopulation
 from .ensemble import EnsembleResult, Ensemble

--- a/maboss/gsparser.py
+++ b/maboss/gsparser.py
@@ -95,6 +95,16 @@ cfg_decl = (var_decl | istate_decl | param_decl | internal_decl
 cfg_grammar = pp.ZeroOrMore(cfg_decl)
 cfg_grammar.ignore('//' + pp.restOfLine)
 
+def loadBNet(bnet_filename):
+    assert bnet_filename.lower().endswith(".bnet"), "wrong extension for BNet file"
+
+    if "://" in bnet_filename:
+        from colomoto_jupyter.io import ensure_localfile
+        bnet_filename = ensure_localfile(bnet_filename)
+
+    from colomoto_jupyter import import_colomoto_tool
+    biolqm = import_colomoto_tool("biolqm")
+    return biolqm.to_maboss(biolqm.load(bnet_filename))
 
 def load(bnd_filename, *cfg_filenames, **extra_args):
     """Loads a network from a MaBoSS format file.

--- a/maboss/network.py
+++ b/maboss/network.py
@@ -242,6 +242,7 @@ class Network(collections.OrderedDict):
         :param output_list: the nodes to remain external
         :type output_list: list of :py:class:`Node`
         """
+        assert len(set(output_list) - set(self.keys())) == 0, "Node(s) %s not defined !" % str(set(output_list) - set(self.keys()))[1:-1]
         for nd in self:
             self[nd].is_internal = nd not in output_list
 

--- a/maboss/result.py
+++ b/maboss/result.py
@@ -34,7 +34,8 @@ class Result(BaseResult):
             elif not os.path.exists(self._path):
                 os.mkdir(self._path)
 
-        BaseResult.__init__(self, self._path, simul, command)
+        self.output_nodes = [name for name, node in simul.network.items() if not node.is_internal]
+        BaseResult.__init__(self, self._path, simul, command, output_nodes=self.output_nodes)
 
         if workdir is None or len(os.listdir(workdir)) == 0 or overwrite:
 

--- a/maboss/results/baseresult.py
+++ b/maboss/results/baseresult.py
@@ -36,9 +36,9 @@ class BaseResult(ProbTrajResult, StatDistResult):
     in the working directory.
     """
 
-    def __init__(self, path, simul=None, command=None, workdir=None):
+    def __init__(self, path, simul=None, command=None, workdir=None, output_nodes=None):
         
-        ProbTrajResult.__init__(self)
+        ProbTrajResult.__init__(self, output_nodes)
         StatDistResult.__init__(self)
         self._path = path
         self._trajfig = None

--- a/maboss/results/probtrajresult.py
+++ b/maboss/results/probtrajresult.py
@@ -7,8 +7,10 @@ import numpy as np
 
 class ProbTrajResult(object):
     
-    def __init__(self):
-                
+    def __init__(self, output_nodes=None):
+
+        self.output_nodes = output_nodes    
+        
         self.state_probtraj = None
         self.state_probtraj_errors = None
         self.state_probtraj_full = None
@@ -106,7 +108,7 @@ class ProbTrajResult(object):
             raw_states = self._get_raw_states()
             raw_probas = self._get_raw_probas()
             indexes, states = self._get_indexes()
-            nodes = self._get_nodes()
+            nodes = self.output_nodes if self.output_nodes is not None else self._get_nodes()
             nodes_indexes = self._get_nodes_indexes()
 
             new_probs = np.zeros((len(indexes), len(nodes)))
@@ -134,7 +136,7 @@ class ProbTrajResult(object):
             raw_states = self._get_raw_states()
             raw_errors = self._get_raw_errors()
             indexes, states = self._get_indexes()
-            nodes = self._get_nodes()
+            nodes = self.output_nodes if self.output_nodes is not None else self._get_nodes()
             nodes_indexes = self._get_nodes_indexes()
             
             new_errors = np.zeros((len(indexes), len(nodes)))
@@ -369,7 +371,7 @@ class ProbTrajResult(object):
 
     def _get_nodes_indexes(self):
         if self.nodes_indexes is None:
-            nodes = self._get_nodes()
+            nodes = self.output_nodes if self.output_nodes is not None else self._get_nodes()
             self.nodes_indexes = {node:index for index, node in enumerate(nodes)}
         return self.nodes_indexes
 

--- a/maboss/upp/results.py
+++ b/maboss/upp/results.py
@@ -163,7 +163,6 @@ class UpdatePopulationResults:
     def get_nodes_stepwise_probability_distribution(self, nodes=None, nb_cores=1):
         if self.nodes_stepwise_probability_distribution is None or set(nodes) != self.nodes_list_stepwise_probability_distribution:
             
-            self.nodes_list_stepwise_probability_distribution = set(nodes)
             table = self.get_stepwise_probability_distribution(nb_cores=nb_cores)
             
             states = table.columns.values[1:].tolist()
@@ -174,6 +173,8 @@ class UpdatePopulationResults:
                 nodes = get_nodes(states)
             else:
                 nodes = set(nodes)
+            
+            self.nodes_list_stepwise_probability_distribution = nodes
 
             node_dict = {}
             for state in states:

--- a/maboss/upp/upp.py
+++ b/maboss/upp/upp.py
@@ -51,7 +51,7 @@ class UpdatePopulation:
             self._readUppFile()
 
     def run(self, workdir=None, overwrite=None, verbose=False, host=None, port=7777):
-        return UpdatePopulationResults(self, verbose, workdir, overwrite, self.previous_run, host=host, port=port)
+        return UpdatePopulationResults(self, verbose, workdir, overwrite, self.previous_run, host=host, port=port, nodes_init=self.nodes_init)
 
     def _readUppFile(self):
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ if version_info[0] < 3:
     optional_contextlib.append("contextlib2")
 
 setup(name='maboss',
-    version="0.7.8",
+    version="0.7.9",
     packages=find_packages(exclude=["test"]),
     py_modules = ["maboss_setup"],
     author="Nicolas Levy",

--- a/test/Four_cycle.bnd
+++ b/test/Four_cycle.bnd
@@ -1,0 +1,18 @@
+// Toy model of a 4 states cycle
+Node C
+{
+rate_up=0.0;
+rate_down=((NOT A) AND (NOT B)) ? $escape : 0.0 ;
+}
+
+Node A 
+{
+rate_up=(C AND (NOT B))  ? $Au : 0.0;
+rate_down= B ? $Ad : 0.0;
+}
+
+Node B 
+{
+rate_up= A ? $Au : 0.0;
+rate_down = A ? 0.0 : $Ad ;
+}

--- a/test/Four_cycle_FEscape.cfg
+++ b/test/Four_cycle_FEscape.cfg
@@ -1,0 +1,24 @@
+$Au=1;
+$Bu=2;
+$Bd=3;
+$Ad=4;
+$escape=10; // self-degradation of C, that makes the 4cycle unstable. 
+
+C.istate=1;
+A.istate=1;
+B.istate=1;
+
+A.refstate=0;
+
+discrete_time = 0;
+use_physrandgen = FALSE;
+seed_pseudorandom = 100;
+
+sample_count = 500000;
+max_time = 5;
+time_tick = 0.01;
+
+thread_count = 4;
+
+statdist_traj_count = 100;
+statdist_cluster_threshold = 0.9;

--- a/test/test_loadmodels.py
+++ b/test/test_loadmodels.py
@@ -5,9 +5,9 @@ import matplotlib
 matplotlib.use('Agg')
 
 from unittest import TestCase
-from maboss import load, set_nodes_istate
+from maboss import load, loadBNet, set_nodes_istate
 from os.path import dirname, join, exists
-
+import shutil
 
 class TestLoadModels(TestCase):
 
@@ -51,7 +51,9 @@ class TestLoadModels(TestCase):
 
 		for i, proba in enumerate(probas):
 			self.assertAlmostEqual(proba, expected_probas[i], delta=proba*1e-6)
-			
+
+		if exists("saved_sim"):
+			shutil.rmtree("saved_sim")
 		res.save("saved_sim")
 		self.assertTrue(exists("saved_sim"))
 		self.assertTrue(exists("saved_sim/saved_sim.bnd"))
@@ -88,3 +90,20 @@ class TestLoadModels(TestCase):
 		self.assertEqual([type(value) for value in istate[("TCR_b1", "TCR_b2", "CD28")].values()], [str, str, str])
 		self.assertEqual([type(value) for value in istate[("PI3K_b1", "PI3K_b2")].values()], [float, float, float])
 		self.assertEqual([type(value) for value in istate["TGFB"].values()], [str, str])
+
+	def test_loadbnet(self):
+
+		sim = loadBNet(
+			join(dirname(__file__), "ensemble", "TC2_BN_0.bnet")
+		)
+
+		self.assertEqual(
+			list(sim.network.keys()), 
+			[
+				'AHR', 'BCL6', 'CEBPB', 'CTCF', 'E2F3', 'E2F7', 'EBF1', 'EGR3', 'ESRRA', 'ETV5', 
+				'FOSL1', 'FOSL2', 'FOXM1', 'FOXO3', 'HEY1', 'HIF1A', 'HMGA2', 'HSF1', 'HSF2', 
+				'KLF15', 'KLF9', 'MAX', 'NFAT5', 'NFATC3', 'NFE2L2', 'NR1H3', 'NR2F1', 'NR2F2',
+				'NR3C1', 'PPARG', 'RARA', 'RBPJ', 'RUNX2', 'SMAD3', 'SNAI1', 'SP3', 'STAT5A', 
+				'TCF12', 'THAP11', 'TP53', 'TP63', 'VDR', 'XBP1', 'YBX1', 'YY1', 'ZNF143'
+			]
+		)

--- a/test/test_probtrajs.py
+++ b/test/test_probtrajs.py
@@ -81,3 +81,24 @@ class TestProbTrajs(TestCase):
 			res.get_nodes_probtraj().sort_index(axis=1), 
 			res_nodes_probtraj.sort_index(axis=1)
 		).all())
+
+	def test_toyexample(self):
+
+		path = dirname(__file__)
+		sim = load(join(path, "Four_cycle.bnd"), join(path, "Four_cycle_FEscape.cfg"))
+		set_nodes_istate(sim, ["A", "B", "C"], [1, 0])
+		res = sim.run()
+		self.assertEqual(
+			list(res.get_nodes_probtraj().columns.values),
+			['A', 'B', 'C']
+		)
+
+		sim.network.set_output(['A', 'B'])
+		res = sim.run()
+		self.assertEqual(
+			list(res.get_nodes_probtraj().columns.values),
+			['A', 'B']
+		)
+
+		with self.assertRaises(AssertionError, msg="Node(s) 'D' not defined !"):
+			sim.network.set_output(['A', 'B', 'C', 'E'])


### PR DESCRIPTION
When computing the node probability trajectories, we would only return a node probability when it was non-zero. Now we uses the defined outputs of the model, ensuring all outputs would be present even if their probability is zero.

I also added a direct maboss.loadBNet(file) function, to load a bnet file as a maboss model directly (without explicitely callling biolqm). 

Finally, when selecting output variables, there was no error checking that each variable was indeed a defined node. Now the library will return a failed assert if it is the case.