### PR TITLE
Fix two bugs in parser

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pyMaBoSS" %}
-{% set version = "0.7.10" %}
+{% set version = "0.7.11" %}
 package:
   name: '{{ name|lower }}'
   version: '{{ version }}'

--- a/maboss/gsparser.py
+++ b/maboss/gsparser.py
@@ -88,7 +88,7 @@ internal_decl = pp.Group(varName("node") + ~pp.White()
 
 refstate_decl = pp.Group(varName("node") + ~pp.White()
                          + pp.Suppress(".refstate") + pp.Suppress('=')
-                         + booleanStr("refstate_val")
+                         + numOrBool("refstate_val")
                          + pp.Suppress(';'))
 
 cfg_decl = (var_decl | istate_decl | param_decl | internal_decl

--- a/maboss/gsparser.py
+++ b/maboss/gsparser.py
@@ -211,8 +211,8 @@ def _read_bnd(string, is_internal_list):
         for token in parse_bnd:
             interns = {v.lhs: v.rhs for v in token.interns}
             logic = interns.pop('logic') if 'logic' in interns else None
-            rate_up = interns.pop('rate_up')
-            rate_down = interns.pop('rate_down')
+            rate_up = interns.pop('rate_up') if 'rate_up' in interns.keys() else "@logic ? 1.0 : 0.0"
+            rate_down = interns.pop('rate_down') if 'rate_down' in interns.keys() else "@logic ? 0.0 : 1.0"
 
             internal = (is_internal_list[token.name]
                         if token.name in is_internal_list

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ if version_info[0] < 3:
     optional_contextlib.append("contextlib2")
 
 setup(name='maboss',
-    version="0.7.10",
+    version="0.7.11",
     packages=find_packages(exclude=["test"]),
     py_modules = ["maboss_setup"],
     author="Nicolas Levy",


### PR DESCRIPTION
Two bugs in the parser that Gautier found : 
- Refstate should allow -1 values (which ignores it)
- A node can have non-defined rates. In this case, default rates are used
