### PR TITLE
Ensemble features and bugfixes

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pyMaBoSS" %}
-{% set version = "0.7.13" %}
+{% set version = "0.7.14" %}
 package:
   name: '{{ name|lower }}'
   version: '{{ version }}'

--- a/maboss/ensemble/ensemble.py
+++ b/maboss/ensemble/ensemble.py
@@ -22,25 +22,12 @@ class Ensemble(object):
 
     def __init__(self, path, cfg_filename=None, individual_istates=collections.OrderedDict(), individual_mutations=collections.OrderedDict(), models=None, *args, **kwargs):
 
-        if path.lower().endswith(".zip"):
-            self.models_path = tempfile.mkdtemp(prefix="maboss-ensemble")
-            def cleanup(d):
-                shutil.rmtree(d)
-            atexit.register(cleanup, self.models_path)
-            with ZipFile(path) as zin:
-                zin.extractall(self.models_path)
-        else:
-            self.models_path = path
+        self.set_models_path(path)
+        
         self.param = _default_parameter_list
         self.param["use_physrandgen"] = 0
 
-        if models is None:
-            self.models_files = [
-                os.path.join(self.models_path, filename)
-                for filename in os.listdir(self.models_path)
-                if filename.endswith(".bnet") or filename.endswith(".bnd")
-            ]
-        else:
+        if models is not None:
             self.models_files = [
                 os.path.join(self.models_path, filename)
                 for filename in models

--- a/maboss/ensemble/ensemble.py
+++ b/maboss/ensemble/ensemble.py
@@ -106,6 +106,7 @@ class Ensemble(object):
         ensemble.individual_istates = self.individual_istates.copy()
         ensemble.models_files = self.models_files.copy()
         ensemble.nodes = self.nodes.copy()
+        ensemble.mutations = self.mutations.copy()
         return ensemble
 
     def get_maboss_cmd(self):

--- a/maboss/ensemble/ensemble.py
+++ b/maboss/ensemble/ensemble.py
@@ -132,7 +132,16 @@ class Ensemble(object):
         # return EnsembleResult(self.models_files, self._cfg, "res", self.individual_results, self.random_sampling)
 
     def set_models_path(self, path):
-        self.models_path = path
+        if path.lower().endswith(".zip"):
+            self.models_path = tempfile.mkdtemp(prefix="maboss-ensemble")
+            def cleanup(d):
+                shutil.rmtree(d)
+            atexit.register(cleanup, self.models_path)
+            with ZipFile(path) as zin:
+                zin.extractall(self.models_path)
+        else:
+            self.models_path = path
+        
         self.models_files = [
             os.path.join(self.models_path, filename) 
             for filename in os.listdir(self.models_path)

--- a/maboss/ensemble/result.py
+++ b/maboss/ensemble/result.py
@@ -17,6 +17,7 @@ import pandas as pd
 import matplotlib.pyplot as plt 
 from re import match
 import ast
+import math
 
 class EnsembleResult(BaseResult):
   
@@ -283,7 +284,7 @@ class EnsembleResult(BaseResult):
                 **args
             )
 
-    def plotPCA(self, pca, X_pca, samples, features, colors=None, alpha=1, compare=None, figsize=(20, 12), show_samples=False, show_features=True, ax=None):
+    def plotPCA(self, pca, X_pca, samples, features, colors=None, alpha=1, compare=None, figsize=(20, 12), show_samples=False, show_features=True, ax=None, cutoff_arrows=None):
         
         if ax is None:
             fig = plt.figure(figsize=figsize)
@@ -342,8 +343,9 @@ class EnsembleResult(BaseResult):
   
         if show_features:
             for i, v in enumerate(arrows_raw):
-                ax.arrow(0, 0, v[0], v[1], linewidth=2, color='red')
-                ax.text(v[0], v[1], samples[i], color='black', ha='right', va='top', fontsize=18)
+                if cutoff_arrows is None or math.sqrt(math.pow(v[0], 2) + math.pow(v[1], 2)) > cutoff_arrows:
+                    ax.arrow(0, 0, v[0], v[1], linewidth=2, color='red')
+                    ax.text(v[0], v[1], samples[i], color='black', ha='right', va='top', fontsize=18)
 
             ax.set_xlim(min(min_x_values, min_x_arrows)*1.2, max(max_x_values, max_x_arrows)*1.2)
             ax.set_ylim(min(min_y_values, min_y_arrows)*1.2, max(max_y_values, max_y_arrows)*1.2)

--- a/maboss/ensemble/result.py
+++ b/maboss/ensemble/result.py
@@ -221,15 +221,43 @@ class EnsembleResult(BaseResult):
                     os.path.join(output_directory, os.path.basename(self.models_files[model]))
                 )
 
-    def plotSteadyStatesDistribution(self, figsize=None, labels=None, alpha=1, **args):
+    def plotSteadyStatesDistribution(self, figsize=None, compare=None, labels=None, alpha=1, **args):
 
         pca = PCA()
         table = self.get_individual_states_probtraj()
-        mat = table.values
-        pca_res = pca.fit(mat)
-        X_pca = pca.transform(mat)
-        arrows_raw = (np.transpose(pca_res.components_[0:2, :]))
-        self.plotPCA(pca, X_pca, list(table.columns.values), list(table.index.values), labels, alpha, figsize=figsize, **args)
+        if compare is not None:
+            compare_table = compare.get_individual_states_probtraj()
+            
+            # Here we need to make sure all tables have the same columns
+            all_columns = set(list(table.columns) + list(compare_table.columns))
+            for column in all_columns:
+                if column not in table.columns.values:
+                    table[column] = 0
+                if column not in compare_table.columns.values:
+                    compare_table[column] = 0
+            
+            table = table[all_columns]
+            compare_table = compare_table[all_columns]
+    
+            mat = table.values
+            pca_res = pca.fit(mat)
+            X_pca = pca.transform(mat)
+            arrows_raw = (np.transpose(pca_res.components_[0:2, :]))
+        
+            c_pca = pca.transform(compare_table.values)
+            
+            self.plotPCA(
+                pca, X_pca, 
+                list(table.columns.values), list(table.index.values), labels, alpha,
+                compare=c_pca, **args
+            )
+        else:
+            mat = table.values
+            pca_res = pca.fit(mat)
+            X_pca = pca.transform(mat)
+            arrows_raw = (np.transpose(pca_res.components_[0:2, :]))
+        
+            self.plotPCA(pca, X_pca, list(table.columns.values), list(table.index.values), labels, alpha, figsize=figsize, **args)
 
     def plotSteadyStatesNodesDistribution(self, compare=None, labels=None, alpha=1, **args):
 

--- a/maboss/ensemble/result.py
+++ b/maboss/ensemble/result.py
@@ -18,6 +18,8 @@ import matplotlib.pyplot as plt
 from re import match
 import ast
 import math
+import matplotlib.pyplot as plt
+from mpl_toolkits.mplot3d import Axes3D
 
 class EnsembleResult(BaseResult):
   
@@ -221,6 +223,46 @@ class EnsembleResult(BaseResult):
                     self.models_files[model], 
                     os.path.join(output_directory, os.path.basename(self.models_files[model]))
                 )
+
+    def plotStates3D(self, dims, figsize=None, compare=None, ax=None, **args):
+        if len(dims) == 3:
+            table = self.get_individual_states_probtraj()
+            
+            if ax is None:
+                fig = plt.figure()
+                ax = fig.add_subplot(111, projection='3d')
+                
+            
+            if compare is not None:
+                
+                m_table = compare.get_individual_states_probtraj()
+                
+                # Here we need to make sure all tables have the same columns
+                all_columns = set(list(table.columns) + list(m_table.columns) + dims)
+                
+                for column in all_columns:
+                    if column not in table.columns.values:
+                        table[column] = 0
+                    if column not in m_table.columns.values:
+                        m_table[column] = 0
+                
+                table = table[all_columns]
+                m_table = m_table[all_columns]
+                    
+                values = table[dims].values
+                m_values = m_table[dims].values
+                ax.scatter(values[:, 0], values[:, 1], values[:, 2], **args)
+                ax.scatter(m_values[:, 0], m_values[:, 1], m_values[:, 2], **args)
+            else:
+                values = table[dims].values
+                ax.scatter(values[:, 0], values[:, 1], values[:, 2], **args)
+
+                
+                
+                
+            ax.set_xlabel(dims[0])
+            ax.set_ylabel(dims[1])
+            ax.set_zlabel(dims[2])
 
     def plotSteadyStatesDistribution(self, figsize=None, compare=None, labels=None, alpha=1, **args):
 

--- a/maboss/ensemble/result.py
+++ b/maboss/ensemble/result.py
@@ -283,17 +283,20 @@ class EnsembleResult(BaseResult):
                 **args
             )
 
-    def plotPCA(self, pca, X_pca, samples, features, colors=None, alpha=1, compare=None, figsize=(20, 12), show_samples=False, show_features=True):
-        fig = plt.figure(figsize=figsize)
+    def plotPCA(self, pca, X_pca, samples, features, colors=None, alpha=1, compare=None, figsize=(20, 12), show_samples=False, show_features=True, ax=None):
+        
+        if ax is None:
+            fig = plt.figure(figsize=figsize)
+            ax = fig.add_subplot(1,1,1)
 
         if colors is None:
-            plt.scatter(X_pca[:, 0], X_pca[:, 1], alpha=alpha)
+            ax.scatter(X_pca[:, 0], X_pca[:, 1], alpha=alpha)
         else:
             legend = ["Cluster #%d" % (i + 1) for i in colors]
 
             c_colors = ["C%d" % color for color in colors]
             
-            scatter = plt.scatter(X_pca[:, 0], X_pca[:, 1], c=c_colors, s=50, alpha=alpha, label=colors)
+            scatter = ax.scatter(X_pca[:, 0], X_pca[:, 1], c=c_colors, s=50, alpha=alpha, label=colors)
             import matplotlib.patches as mpatches
             # build the legend
 
@@ -306,10 +309,10 @@ class EnsembleResult(BaseResult):
             legend = plt.legend(handles=patches)
 
         if compare is not None:
-            plt.scatter(compare[:, 0], compare[:, 1], alpha=alpha)
+            ax.scatter(compare[:, 0], compare[:, 1], alpha=alpha)
 
-        plt.xlabel("PC{} ({}%)".format(1, round(pca.explained_variance_ratio_[0] * 100, 2)))
-        plt.ylabel("PC{} ({}%)".format(2, round(pca.explained_variance_ratio_[1] * 100, 2)))
+        ax.set_xlabel("PC{} ({}%)".format(1, round(pca.explained_variance_ratio_[0] * 100, 2)))
+        ax.set_ylabel("PC{} ({}%)".format(2, round(pca.explained_variance_ratio_[1] * 100, 2)))
                 
         arrows_raw = pca.components_[0:2, :].T
         
@@ -335,18 +338,18 @@ class EnsembleResult(BaseResult):
   
         if show_samples:
             for i, txt in enumerate(features):
-                plt.annotate(txt, (X_pca[i, 0], X_pca[i, 1]))
+                ax.annotate(txt, (X_pca[i, 0], X_pca[i, 1]))
   
         if show_features:
             for i, v in enumerate(arrows_raw):
-                plt.arrow(0, 0, v[0], v[1], linewidth=2, color='red')
-                plt.text(v[0], v[1], samples[i], color='black', ha='right', va='top', fontsize=18)
+                ax.arrow(0, 0, v[0], v[1], linewidth=2, color='red')
+                ax.text(v[0], v[1], samples[i], color='black', ha='right', va='top', fontsize=18)
 
-            plt.xlim(min(min_x_values, min_x_arrows)*1.2, max(max_x_values, max_x_arrows)*1.2)
-            plt.ylim(min(min_y_values, min_y_arrows)*1.2, max(max_y_values, max_y_arrows)*1.2)
+            ax.set_xlim(min(min_x_values, min_x_arrows)*1.2, max(max_x_values, max_x_arrows)*1.2)
+            ax.set_ylim(min(min_y_values, min_y_arrows)*1.2, max(max_y_values, max_y_arrows)*1.2)
         else:
-            plt.xlim(min_x_values*1.2, max_x_values*1.2)
-            plt.ylim(min_y_values*1.2, max_y_values*1.2)
+            ax.set_xlim(min_x_values*1.2, max_x_values*1.2)
+            ax.set_ylim(min_y_values*1.2, max_y_values*1.2)
 
     def plotTSNESteadyStatesNodesDistribution(self, node_filter=None, state_filter=None, clusters={}, perplexity=50, n_iter=2000, **args):
 

--- a/maboss/figures.py
+++ b/maboss/figures.py
@@ -47,7 +47,7 @@ def plot_node_prob(time_table, ax, palette, legend=True, error_table=None):
 
 
 def plot_piechart(plot_table, ax, palette, embed_labels=False, autopct=4, \
-                    prob_cutoff=0.01):
+                    prob_cutoff=0.01, legend=True):
     plot_line = plot_table.iloc[-1].rename("")  # Takes the last time point
 
     others = plot_line[plot_line <= prob_cutoff].sum()
@@ -83,7 +83,8 @@ def plot_piechart(plot_table, ax, palette, embed_labels=False, autopct=4, \
     ax.pie(plot_line, labels=plotting_labels, radius=1.2,
            startangle=90, colors=color_list, **opts)
     ax.axis('equal')
-    ax.legend(plot_line.index.values, loc=(0.9, 0.2))
+    if legend:
+        ax.legend(plot_line.index.values, loc=(0.9, 0.2))
 
 
 def plot_fix_point(table, ax, palette):

--- a/maboss/results/baseresult.py
+++ b/maboss/results/baseresult.py
@@ -81,7 +81,7 @@ class BaseResult(ProbTrajResult, StatDistResult):
         make_plot_trajectory(table, axes, self.palette, legend=legend, error_table=table_error)
 
     def plot_piechart(self, embed_labels=False, autopct=4, prob_cutoff=0.01,
-                        axes=None):
+                        axes=None, legend=True):
         """Plot the states probability distribution of last time point.
 
         :param float prob_cutoff: states with a probability below this cut-off
@@ -102,7 +102,7 @@ class BaseResult(ProbTrajResult, StatDistResult):
         table = self.get_last_states_probtraj()
         plot_piechart(table, axes, self.palette,
                 embed_labels=embed_labels, autopct=autopct,
-                prob_cutoff=prob_cutoff)
+                prob_cutoff=prob_cutoff, legend=legend)
 
     def plot_fixpoint(self, axes=None):
         """Plot the probability distribution of fixed point."""

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ if version_info[0] < 3:
     optional_contextlib.append("contextlib2")
 
 setup(name='maboss',
-    version="0.7.13",
+    version="0.7.14",
     packages=find_packages(exclude=["test"]),
     py_modules = ["maboss_setup"],
     author="Nicolas Levy",


### PR DESCRIPTION
- Fixed ensemble simulation copy()
- set_models_path now also work with zipped ensembles
- legend can be deactivated on piecharts
- PCA model comparison also work on state distributions
- PCA methods now allow a matplotlib axes as parameter
- PCA methods allow a cutoff_arrows to hide small arrows. 
- Added a 3D plotting method for model distributions